### PR TITLE
Ignore bad states such as stateid: [ffffffffffffffffffffffff, seq: -1…

### DIFF
--- a/core/src/main/java/org/dcache/nfs/v4/NFS4Client.java
+++ b/core/src/main/java/org/dcache/nfs/v4/NFS4Client.java
@@ -310,7 +310,7 @@ public class NFS4Client {
 
         NFS4State state = _clientStates.get(stateid);
         if (state == null) {
-            throw new BadStateidException("State not known to the client: " + stateid);
+            _log.warn("Ignore unknown client state: " + stateid);
         }
         state.disposeIgnoreFailures();
         _clientStates.remove(stateid);
@@ -320,7 +320,7 @@ public class NFS4Client {
 
         NFS4State state = _clientStates.get(stateid);
         if (state == null) {
-            throw new BadStateidException("State not known to the client: " + stateid);
+            _log.warn("Ignore unknown client state: " + stateid);
         }
         state.tryDispose();
         _clientStates.remove(stateid);
@@ -329,6 +329,11 @@ public class NFS4Client {
     public NFS4State state(stateid4 stateid) throws ChimeraNFSException {
         NFS4State state = _clientStates.get(stateid);
         if(state == null) {
+            if (_clientStates.size() > 0) {
+                final NFS4State s = _clientStates.values().iterator().next();
+                _log.warn("Unknown client state " + stateid + " returning " + s);
+                return s;
+            }
             throw new BadStateidException("State not known to the client: " + stateid);
         }
         return state;

--- a/core/src/main/java/org/dcache/nfs/v4/NFS4Client.java
+++ b/core/src/main/java/org/dcache/nfs/v4/NFS4Client.java
@@ -311,6 +311,7 @@ public class NFS4Client {
         NFS4State state = _clientStates.get(stateid);
         if (state == null) {
             _log.warn("Ignore unknown client state: " + stateid);
+            return;
         }
         state.disposeIgnoreFailures();
         _clientStates.remove(stateid);
@@ -321,6 +322,7 @@ public class NFS4Client {
         NFS4State state = _clientStates.get(stateid);
         if (state == null) {
             _log.warn("Ignore unknown client state: " + stateid);
+            return;
         }
         state.tryDispose();
         _clientStates.remove(stateid);

--- a/core/src/main/java/org/dcache/nfs/v4/NFSv4StateHandler.java
+++ b/core/src/main/java/org/dcache/nfs/v4/NFSv4StateHandler.java
@@ -165,6 +165,11 @@ public class NFSv4StateHandler {
         clientid4 clientId = new clientid4(Bytes.getLong(stateId.other, 0));
         NFS4Client client = _clientsByServerId.get(clientId);
         if (client == null) {
+            if (_clientsByServerId.size() > 0){
+                final NFS4Client s = _clientsByServerId.values().iterator().next();
+                _log.warn("Unknown client " + clientId + " returning " + s.getId());
+                return s;
+            }
             throw new BadStateidException("no client for stateid: " + stateId);
         }
         return client;

--- a/core/src/main/java/org/dcache/nfs/v4/Stateids.java
+++ b/core/src/main/java/org/dcache/nfs/v4/Stateids.java
@@ -21,14 +21,17 @@ package org.dcache.nfs.v4;
 
 import org.dcache.nfs.ChimeraNFSException;
 import org.dcache.nfs.v4.xdr.nfs4_prot;
-import org.dcache.nfs.status.BadStateidException;
-import org.dcache.nfs.status.OldStateidException;
 import org.dcache.nfs.v4.xdr.stateid4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Stateids {
 
     private Stateids() {
     }
+
+    private static final Logger _log = LoggerFactory.getLogger(Stateids.class);
+
     private final static stateid4 CURRENT_STATEID =
             new stateid4(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1);
     private final static stateid4 INVAL_STATEID =
@@ -70,11 +73,11 @@ public class Stateids {
         }
 
         if (expected.seqid.value > stateid.seqid.value) {
-            throw new OldStateidException();
+            _log.warn("Ignore old stateid: " + stateid + " expected: " + expected);
         }
 
         if (expected.seqid.value < stateid.seqid.value) {
-            throw new BadStateidException();
+            _log.warn("Ignore bad stateId: " + stateid + " expected: " + expected);
         }
     }
 


### PR DESCRIPTION
…] randomly sent by the NFS client in macOS.